### PR TITLE
feat: preserve ttl on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,13 @@ go test -bench=. -benchmem
 For this benchmark, memory was created with the following specs: `1024 bytes per record`, `4096 records per shard`, `256 shards (max)`.
 
 ```
-BenchmarkCacheNewMedium-12       	     291	   3670372 ns/op	22776481 B/op	   12408 allocs/op
-BenchmarkCacheSetMedium-12       	 1928548	       620.3 ns/op	      63 B/op	       1 allocs/op
-BenchmarkCacheGetMedium-12       	16707145	        69.87 ns/op	       0 B/op	       0 allocs/op
+goos: linux
+goarch: amd64
+pkg: github.com/praserx/atomic-cache/v2
+cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
+BenchmarkCacheNewMedium-12       	     288	   4109240 ns/op	22750002 B/op	   12405 allocs/op
+BenchmarkCacheSetMedium-12       	 4499152	       269.8 ns/op	      16 B/op	       0 allocs/op
+BenchmarkCacheGetMedium-12       	19747963	        59.72 ns/op	       0 B/op	       0 allocs/op
 ```
 
 *If you want do some special bencharking, go ahead.*
@@ -96,18 +100,26 @@ BenchmarkCacheGetMedium-12       	16707145	        69.87 ns/op	       0 B/op	   
 
 **SET**
 ```
-BenchmarkAtomicCacheSet-12       	 2921170	       413.0 ns/op	      55 B/op	       2 allocs/op
-BenchmarkBigCacheSet-12          	 3448020	       345.5 ns/op	       0 B/op	       0 allocs/op
-BenchmarkFreeCacheSet-12         	 4777364	       217.2 ns/op	      65 B/op	       1 allocs/op
-BenchmarkHashicorpCacheSet-12    	 6208528	       202.2 ns/op	      65 B/op	       3 allocs/op
+goos: linux
+goarch: amd64
+pkg: github.com/praserx/atomic-cache/v2
+cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
+BenchmarkAtomicCacheSet-12       	 5755452	       195.3 ns/op	      27 B/op	       1 allocs/op
+BenchmarkBigCacheSet-12          	 4290684	       286.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFreeCacheSet-12         	 5806412	       199.3 ns/op	      65 B/op	       1 allocs/op
+BenchmarkHashicorpCacheSet-12    	 6333306	       170.0 ns/op	      65 B/op	       3 allocs/op
 ```
 
 **GET**
 ```
-BenchmarkAtomicCacheGet-12       	 9697010	       121.7 ns/op	       0 B/op	       0 allocs/op
-BenchmarkBigCacheGet-12          	 4031352	       295.3 ns/op	      88 B/op	       2 allocs/op
-BenchmarkFreeCacheGet-12         	 4813386	       276.8 ns/op	      88 B/op	       2 allocs/op
-BenchmarkHashicorpCacheGet-12    	11071472	       107.4 ns/op	      16 B/op	       1 allocs/op
+goos: linux
+goarch: amd64
+pkg: github.com/praserx/atomic-cache/v2
+cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
+BenchmarkAtomicCacheGet-12       	13004460	        97.27 ns/op	       0 B/op	       0 allocs/op
+BenchmarkBigCacheGet-12          	 4403041	       272.5 ns/op	      88 B/op	       2 allocs/op
+BenchmarkFreeCacheGet-12         	 5586747	       231.9 ns/op	      88 B/op	       2 allocs/op
+BenchmarkHashicorpCacheGet-12    	11445339	        99.70 ns/op	      16 B/op	       1 allocs/op
 ```
 
 ## License

--- a/cache.go
+++ b/cache.go
@@ -195,7 +195,7 @@ func (a *AtomicCache) Set(key string, data []byte, expire time.Duration) error {
 	} else {
 		if val.ShardSection != shardSectionID {
 			// Key exists but data size changed: move to new section, free old record.
-			// Explaination: If the record size changed and data should be stored in a different
+			// Explanation: If the record size changed and data should be stored in a different
 			// shard section, we need to free the old record and allocate a new record in
 			// the correct shard section.
 			a.Lock()

--- a/cache.go
+++ b/cache.go
@@ -229,7 +229,7 @@ func (a *AtomicCache) Set(key string, data []byte, expire time.Duration) error {
 			a.Unlock()
 		} else if si, ok := a.getEmptyShard(shardSectionID); ok {
 			// No shard with space, allocate new shard.
-			// Explaination: If there is no shard with available space, we allocate a new shard
+			// Explanation: If there is no shard with available space, we allocate a new shard
 			// and set the data in that new shard. This is necessary when all existing shards
 			// are full and we need to create a new shard to accommodate the new record.
 			// This ensures that we can always store new records, even if it means creating a

--- a/cache.go
+++ b/cache.go
@@ -221,7 +221,7 @@ func (a *AtomicCache) Set(key string, data []byte, expire time.Duration) error {
 		a.Lock()
 		if si, ok := a.getShard(shardSectionID); ok {
 			// Found shard with available slot.
-			// Explaination: If we found a shard with available space, we can simply set the data
+			// Explanation: If we found a shard with available space, we can simply set the data
 			// in that shard and update the lookup table with the new record index.
 			// This avoids unnecessary memory allocation and deallocation, improving performance.
 			ri := shardSection.shards[si].Set(data)

--- a/cache.go
+++ b/cache.go
@@ -24,6 +24,10 @@ const (
 	LGSH
 )
 
+// KeepTTL is used for setting expiration time to current expiration time.
+// It means that record will be updated with the same expiration time.
+const KeepTTL = time.Duration(-1)
+
 // AtomicCache structure represents whole cache memory.
 type AtomicCache struct {
 	// RWMutex is used for access to shards array.
@@ -154,50 +158,106 @@ func initShardsSection(shardsSection *ShardsLookup, maxShards, maxRecords, recor
 // space for data. If there is no empty space, new shard is allocated. Otherwise
 // some valid record (FIFO queue) is deleted and new one is stored.
 func (a *AtomicCache) Set(key string, data []byte, expire time.Duration) error {
+	// Reject if data is too large for any shard
 	if len(data) > int(a.RecordSizeLarge) {
 		return ErrDataLimit
 	}
 
+	// Track if this is a new record and if garbage collection should be triggered
 	new := false
 	collectGarbage := false
+
+	// Select the appropriate shard section based on data size
 	shardSection, shardSectionID := a.getShardsSectionBySize(len(data))
 
-	a.Lock()
-	if val, ok := a.lookup[key]; !ok {
+	var (
+		exists bool
+		val    LookupRecord
+	)
+
+	// Only lock for shared state mutation: check if key exists in lookup
+	a.RLock()
+	val, exists = a.lookup[key]
+	a.RUnlock()
+
+	// Determine expiration time: if KeepTTL and record exists, preserve old
+	// expiration; otherwise, calculate new.
+	var expireTime time.Time
+	if expire == KeepTTL && exists {
+		expireTime = val.Expiration
+	} else {
+		expireTime = a.getExprTime(expire)
+	}
+
+	if !exists {
+		// Key is new, will allocate new record
 		new = true
 	} else {
 		if val.ShardSection != shardSectionID {
+			// Key exists but data size changed: move to new section, free old record.
+			// Explaination: If the record size changed and data should be stored in a different
+			// shard section, we need to free the old record and allocate a new record in
+			// the correct shard section.
+			a.Lock()
 			shardSection.shards[val.ShardIndex].Free(val.RecordIndex)
 			val.RecordIndex = shardSection.shards[val.ShardIndex].Set(data)
-			a.lookup[key] = LookupRecord{ShardIndex: val.ShardIndex, ShardSection: shardSectionID, RecordIndex: val.RecordIndex, Expiration: a.getExprTime(expire)}
+			a.lookup[key] = LookupRecord{ShardIndex: val.ShardIndex, ShardSection: shardSectionID, RecordIndex: val.RecordIndex, Expiration: expireTime}
+			a.Unlock()
 		} else {
-			prevShardSection := a.getShardsSectionByID(val.ShardSection)
-			prevShardSection.shards[val.ShardIndex].Free(val.RecordIndex)
-			new = true
+			// Key exists in same section: update existing record.
+			// Explaination: If the record size is the same, we can simply update the existing record
+			// in the same shard section without needing to free it first.
+			// This is more efficient as it avoids unnecessary memory allocation and deallocation.
+			// This is a performance optimization to avoid unnecessary memory allocation and deallocation.
+			// It assumes that the record size has not changed and we can safely update it.
+			a.Lock()
+			shardSection.shards[val.ShardIndex].Seti(val.RecordIndex, data)
+			a.Unlock()
 		}
 	}
 
 	if new {
+		// Allocate new record: try to find a shard with space, or allocate a new shard, or buffer if full
+		a.Lock()
 		if si, ok := a.getShard(shardSectionID); ok {
+			// Found shard with available slot.
+			// Explaination: If we found a shard with available space, we can simply set the data
+			// in that shard and update the lookup table with the new record index.
+			// This avoids unnecessary memory allocation and deallocation, improving performance.
 			ri := shardSection.shards[si].Set(data)
-			a.lookup[key] = LookupRecord{ShardIndex: si, ShardSection: shardSectionID, RecordIndex: ri, Expiration: a.getExprTime(expire)}
+			a.lookup[key] = LookupRecord{ShardIndex: si, ShardSection: shardSectionID, RecordIndex: ri, Expiration: expireTime}
+			a.Unlock()
 		} else if si, ok := a.getEmptyShard(shardSectionID); ok {
+			// No shard with space, allocate new shard.
+			// Explaination: If there is no shard with available space, we allocate a new shard
+			// and set the data in that new shard. This is necessary when all existing shards
+			// are full and we need to create a new shard to accommodate the new record.
+			// This ensures that we can always store new records, even if it means creating a
+			// new shard when all existing shards are full.
 			shardSection.shards[si] = NewShard(a.MaxRecords, a.getRecordSizeByShardSectionID(shardSectionID))
 			ri := shardSection.shards[si].Set(data)
-			a.lookup[key] = LookupRecord{ShardIndex: si, ShardSection: shardSectionID, RecordIndex: ri, Expiration: a.getExprTime(expire)}
+			a.lookup[key] = LookupRecord{ShardIndex: si, ShardSection: shardSectionID, RecordIndex: ri, Expiration: expireTime}
+			a.Unlock()
 		} else {
-			if len(a.buffer) <= int(a.MaxRecords) {
+			// All shards full, buffer the request or return error if buffer is full.
+			if len(a.buffer) < int(a.MaxRecords) {
+				// Buffer the request if there is space in buffer.
+				// Explaination: If the buffer has space, we can store the request in the buffer
+				// instead of allocating a new shard. This allows us to handle more requests without
+				// immediately allocating new memory, which can be more efficient.
+				// This is useful when the cache is under heavy load and we want to avoid
+				// allocating new shards for every request.
 				a.buffer = append(a.buffer, BufferItem{Key: key, Data: data, Expire: expire})
+				a.Unlock()
 			} else {
 				a.Unlock()
 				return ErrFullMemory
 			}
-
 			collectGarbage = true
 		}
 	}
-	a.Unlock()
 
+	// Trigger garbage collection if needed
 	if (atomic.AddUint32(&a.GcCounter, 1) == a.GcStarter) || collectGarbage {
 		atomic.StoreUint32(&a.GcCounter, 0)
 		go a.collectGarbage()

--- a/cache.go
+++ b/cache.go
@@ -205,7 +205,7 @@ func (a *AtomicCache) Set(key string, data []byte, expire time.Duration) error {
 			a.Unlock()
 		} else {
 			// Key exists in same section: update existing record.
-			// Explaination: If the record size is the same, we can simply update the existing record
+			// Explanation: If the record size is the same, we can simply update the existing record
 			// in the same shard section without needing to free it first.
 			// This is more efficient as it avoids unnecessary memory allocation and deallocation.
 			// This is a performance optimization to avoid unnecessary memory allocation and deallocation.

--- a/cache.go
+++ b/cache.go
@@ -242,7 +242,7 @@ func (a *AtomicCache) Set(key string, data []byte, expire time.Duration) error {
 			// All shards full, buffer the request or return error if buffer is full.
 			if len(a.buffer) < int(a.MaxRecords) {
 				// Buffer the request if there is space in buffer.
-				// Explaination: If the buffer has space, we can store the request in the buffer
+				// Explanation: If the buffer has space, we can store the request in the buffer
 				// instead of allocating a new shard. This allows us to handle more requests without
 				// immediately allocating new memory, which can be more efficient.
 				// This is useful when the cache is under heavy load and we want to avoid

--- a/shard.go
+++ b/shard.go
@@ -41,6 +41,15 @@ func (s *Shard) Set(data []byte) (i int) {
 	return
 }
 
+// Seti updates data in shard memory based on index. To preserve performance,
+// it does not check if index is valid. It is responsibility of caller to ensure
+// that index is valid and within bounds of shard.
+func (s *Shard) Seti(i int, data []byte) {
+	s.Lock() // Lock for writing and reading
+	s.slots[i].Set(data)
+	s.Unlock() // Unlock for writing and reading
+}
+
 // Get returns bytes from shard memory based on index. If array on output is
 // empty, then record is not exists.
 func (s *Shard) Get(index int) (v []byte) {


### PR DESCRIPTION
This pull request introduces several improvements and optimizations to the `atomic-cache` library, including enhanced benchmarking documentation, new features for cache expiration handling, performance optimizations in the `Set` method, and additional test coverage for shards and cache behavior.

### Benchmarking Updates:
* Updated benchmark results in `README.md` to reflect the latest performance metrics, including reduced memory allocations and improved operation times. Added system details (e.g., OS, architecture, and CPU) for reproducibility. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R94) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R122)

### New Features:
* Introduced a new constant `KeepTTL` to allow updates to cache records while preserving their existing expiration times.
* Added support for `KeepTTL` in the `Set` method, enabling more flexible expiration management.

### Performance Optimizations:
* Optimized the `Set` method in `cache.go` to minimize locking and improve efficiency when updating existing records or allocating new ones.
* Added the `Seti` method in `shard.go` to directly update shard memory by index, reducing overhead for in-place updates.

### Test Enhancements:
* Added unit tests for the new `KeepTTL` functionality to ensure expiration times are preserved during updates.
* Expanded shard tests to include scenarios for `Seti`, slot availability, and shard empty state validation.

These changes collectively improve the library's performance, flexibility, and reliability.