### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/atomiccache-test.yml
+++ b/.github/workflows/atomiccache-test.yml
@@ -1,5 +1,7 @@
 name: Package atomiccache test
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/praserx/atomic-cache/security/code-scanning/1](https://github.com/praserx/atomic-cache/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Based on the workflow's tasks, the minimal required permissions are `contents: read` to allow read-only access to the repository contents. No write permissions are necessary since the workflow only performs testing and caching operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
